### PR TITLE
Two step variable definition for special chars in strings

### DIFF
--- a/src/TcBlack/VariableDeclaration.cs
+++ b/src/TcBlack/VariableDeclaration.cs
@@ -73,17 +73,31 @@ namespace TcBlack
             string pattern = 
                 $@"{variable_pattern}{address_pattern}:\s*"
                 + $@"{unit_pattern}{initialization};{comment}";
+            
+            string strInitialization = $@"([""'])(?:(?=(\$?))\2.)*?\1(?=\s*;)";
+
+            Match match = Regex.Match(_unformattedCode, strInitialization);
+            string strInit = "";
+            if (match.Length > 0)
+            {
+                strInit = match.Groups[0].Value;
+                _unformattedCode = Regex.Replace(_unformattedCode, strInitialization, "");
+            }
 
             MatchCollection matches = Regex.Matches(_unformattedCode, pattern);
             TcDeclaration variable;
             if (matches.Count > 0)
             {
-                Match match = matches[0];
+                match = matches[0];
+                if (strInit.Length == 0)
+                {
+                    strInit = RemoveWhiteSpaceIfPossible(match.Groups[4].Value);
+                }
                 variable = new TcDeclaration(
                     name: RemoveWhiteSpaceIfPossible(match.Groups[1].Value),
                     allocation: RemoveWhiteSpaceIfPossible(match.Groups[2].Value),
                     dataType: RemoveWhiteSpaceIfPossible(match.Groups[3].Value),
-                    initialization: RemoveWhiteSpaceIfPossible(match.Groups[4].Value),
+                    initialization: strInit,
                     comment: match.Groups[5].Value.Trim()
                 );
             }

--- a/src/TcBlack/VariableDeclaration.cs
+++ b/src/TcBlack/VariableDeclaration.cs
@@ -74,14 +74,14 @@ namespace TcBlack
                 $@"{variable_pattern}{address_pattern}:\s*"
                 + $@"{unit_pattern}{initialization};{comment}";
             
-            string strInitialization = $@"([""'])(?:(?=(\$?))\2.)*?\1(?=\s*;)";
+            string strInitRegex = $@"([""'])(?:(?=(\$?))\2.)*?\1(?=\s*;)";
 
-            Match match = Regex.Match(_unformattedCode, strInitialization);
+            Match match = Regex.Match(_unformattedCode, strInitRegex);
             string strInit = "";
             if (match.Length > 0)
             {
                 strInit = match.Groups[0].Value;
-                _unformattedCode = Regex.Replace(_unformattedCode, strInitialization, "");
+                _unformattedCode = Regex.Replace(_unformattedCode, strInitRegex, "");
             }
 
             MatchCollection matches = Regex.Matches(_unformattedCode, pattern);

--- a/src/TcBlackTests/VariableDeclarationTests.cs
+++ b/src/TcBlackTests/VariableDeclarationTests.cs
@@ -259,5 +259,51 @@ namespace TcBlackTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData(
+            "var: STRING(255):='This is a test string with ;';",
+            "var : STRING(255) := 'This is a test string with ;';"
+        )]
+        [InlineData(
+            "var: STRING(255):='This is a test() string with ;';",
+            "var : STRING(255) := 'This is a test() string with ;';"
+        )]
+        [InlineData(
+            "var: STRING(255):='This) is a test) string with ;';",
+            "var : STRING(255) := 'This) is a test) string with ;';"
+        )]
+        [InlineData(
+            "var: STRING(255):='This( is a test) string with ;';",
+            "var : STRING(255) := 'This( is a test) string with ;';"
+        )]
+        [InlineData(
+            "var: STRING(255):='This( is double \" test) string with ;';",
+            "var : STRING(255) := 'This( is double \" test) string with ;';"
+        )]
+        [InlineData(
+            "var: STRING(255):='This( is a $'asdf$' test) string with ;';",
+            "var : STRING(255) := 'This( is a $'asdf$' test) string with ;';"
+        )]
+        [InlineData(
+            "var: WSTRING(255):=\"This( is a ( test) string with ;\";",
+            "var : WSTRING(255) := \"This( is a ( test) string with ;\";"
+        )]
+        [InlineData(
+            "var: STRING(255):=\"This( is two singles '' test) string with ;\";",
+            "var : STRING(255) := \"This( is two singles '' test) string with ;\";"
+        )]
+        [InlineData(
+            "var: STRING(255):=\"This( is a $\" test) string with ;\";",
+            "var : STRING(255) := \"This( is a $\" test) string with ;\";"
+        )]
+        public void SpecialCharStringInitialization(string unformattedCode, string expected)
+        {
+            VariableDeclaration variable = new VariableDeclaration(
+                unformattedCode: unformattedCode, singleIndent: "    ", lineEnding: "\n"
+            );
+            uint indents = 0;
+            Assert.Equal(expected, variable.Format(ref indents));
+        }
     }
 }


### PR DESCRIPTION
Two step parsing of variable definitions. This is to support special characters inside a string screwing around with the regex.


Fixes #35 