### PR TITLE
Warnings are treated as errors. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,10 @@ jobs:
 
       - name: Build TcBlackCore and CLI
         run: |
-          msbuild src\TcBlackCore\TcBlackCore.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
-          msbuild src\TcBlackCLI\TcBlackCLI.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
-          msbuild src\TcBlackCoreTests\TcBlackCoreTests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
-          msbuild src\TcBlackCLITests\TcBlackCLITests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
+          msbuild src\TcBlackCore\TcBlackCore.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -p:TreatWarningsAsErrors=true
+          msbuild src\TcBlackCLI\TcBlackCLI.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -p:TreatWarningsAsErrors=true
+          msbuild src\TcBlackCoreTests\TcBlackCoreTests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -p:TreatWarningsAsErrors=true
+          msbuild src\TcBlackCLITests\TcBlackCLITests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -p:TreatWarningsAsErrors=true
             
       - name: Setup VSTest Path
         uses: darenm/Setup-VSTest@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,12 +45,12 @@ jobs:
          .\SnInstallPfx.exe src/TcBlackCore/TcBlackCoreSign.pfx '${{ secrets.TCBLACKCORE_PASS }}' 
          .\SnInstallPfx.exe src/TcBlackCLI/TcBlackCLI.pfx '${{ secrets.TCBLACKCLI_PASS }}'
 
-      - name: Build the Core and CLI
+      - name: Build TcBlackCore and CLI
         run: |
-          msbuild src\TcBlackCore\TcBlackCore.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU
-          msbuild src\TcBlackCLI\TcBlackCLI.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU
-          msbuild src\TcBlackCoreTests\TcBlackCoreTests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU
-          msbuild src\TcBlackCLITests\TcBlackCLITests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU
+          msbuild src\TcBlackCore\TcBlackCore.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
+          msbuild src\TcBlackCLI\TcBlackCLI.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
+          msbuild src\TcBlackCoreTests\TcBlackCoreTests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
+          msbuild src\TcBlackCLITests\TcBlackCLITests.csproj -t:Build -p:Configuration=Release -p:Platform=AnyCPU -warnaserror
             
       - name: Setup VSTest Path
         uses: darenm/Setup-VSTest@v1

--- a/src/TcBlackCore/EmptyLine.cs
+++ b/src/TcBlackCore/EmptyLine.cs
@@ -8,7 +8,6 @@
 
         public override string Format(ref int indents)
         {
-            var notUsed = "test for static code analyses";
             return Globals.indentation.Repeat(indents);
         }
     }


### PR DESCRIPTION
Build should fail on static code analyses warning.

Closes #67 